### PR TITLE
fix(ant): clean xar name

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -40,7 +40,7 @@
         <echo message="Creating xar file..."/>
         <echo message="------------------------------------------------------------"/>
         
-        <zip basedir="${basedir}" destfile="${build.dir}/${app.name}-${app.version}.xar">
+        <zip basedir="${basedir}" destfile="${build.dir}/${app.name}.xar">
             <exclude name="${build.dir}/**"/>
             <exclude name="*.tmpl"/>
             <exclude name=".github/**"/>


### PR DESCRIPTION
By removing the version number from the `.xar` file-name we can greatly simplify the automation of the container builds. 

see https://github.com/Jinntec/hsg-project